### PR TITLE
RHBRMS-2784 - XStream: DoS when unmarshalling void type (#75)

### DIFF
--- a/drools-eclipse/org.drools.eclipse/src/main/java/org/drools/eclipse/debug/AuditView.java
+++ b/drools-eclipse/org.drools.eclipse/src/main/java/org/drools/eclipse/debug/AuditView.java
@@ -118,6 +118,8 @@ public class AuditView extends AbstractDebugView {
         List<LogEvent> eventList = new ArrayList<LogEvent>();
         try {
             XStream xstream = new XStream();
+            String[] voidDeny = {"void.class", "Void.class"};
+            xstream.denyTypes(voidDeny);
             ObjectInputStream in = xstream.createObjectInputStream( new FileReader(logFileName) );
             try {
                 while (true) {


### PR DESCRIPTION
(cherry picked from commit 3d84cd2d0f4726891fdc415101c52e33b70fe8e6)
(cherry picked from commit c3d0df1de13602dea6010aea9881f5f57717a4bb)