### PR TITLE
AF-593+: Move uberfire-maven-utils to kie-soup.

### DIFF
--- a/drools-eclipse/org.drools.eclipse/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.drools.eclipse/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Eclipse-BuddyPolicy: registered
 Bundle-ClassPath: .,
  lib/kie-api.jar,
  lib/kie-internal.jar,
- lib/uberfire-maven-support.jar,
+ lib/kie-soup-maven-support.jar,
  lib/drools-core.jar,
  lib/drools-compiler.jar,
  lib/drools-decisiontables.jar,

--- a/drools-eclipse/org.drools.eclipse/pom.xml
+++ b/drools-eclipse/org.drools.eclipse/pom.xml
@@ -88,7 +88,7 @@
               <includeArtifactIds>
                 kie-api,
                 kie-internal,
-                uberfire-maven-support,
+                kie-soup-maven-support,
                 drools-core,
                 drools-compiler,
                 guvnor-api,


### PR DESCRIPTION
Please see this [PR](https://github.com/kiegroup/kie-soup/pull/8) for general discussion.