### PR TITLE
Use <target> instead of deprecated <tasks> in antrun plugin config

### DIFF
--- a/drools-eclipse/org.drools.eclipse/pom.xml
+++ b/drools-eclipse/org.drools.eclipse/pom.xml
@@ -29,36 +29,13 @@
             <id>clean lib</id>
             <phase>clean</phase>
             <configuration>
-              <tasks>
+              <target>
                 <delete>
                   <fileset dir="lib" includes="**/*.jar" excludes="**/.svn"/>
                 </delete>
                 <delete dir="help/shared"/>
                 <delete dir="help/eclipse"/>
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-
-          <execution>
-            <id>unzip manual</id>
-            <phase>process-resources</phase>
-            <configuration>
-              <tasks>
-                <!--unzip src="lib/drools-docs-introduction-eclipse.war" dest="help/introduction" /-->
-                <!--<unzip src="lib/drools-docs-expert-eclipse.war" dest="help/expert" />-->
-                <!--<unzip src="lib/drools-docs-fusion-eclipse.war" dest="help/fusion" />-->
-                <!--<unzip src="lib/drools-docs-flow-eclipse.war" dest="help/flow" />--><!-- TODO flow has been renamed to jbpm -->
-                <!--<unzip src="lib/drools-docs-guvnor-eclipse.war" dest="help/guvnor" />-->
-
-                <!--<delete file="lib/drools-docs-introduction-eclipse.war" />-->
-                <!--<delete file="lib/drools-docs-expert-eclipse.war" />--><!-- TODO flow has been renamed to jbpm -->
-                <!--<delete file="lib/drools-docs-fusion-eclipse.war" />-->
-                <!--<delete file="lib/drools-docs-flow-eclipse.war" />-->
-                <!--<delete file="lib/drools-docs-guvnor-eclipse.war" />-->
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/drools-eclipse/org.jbpm.eclipse/pom.xml
+++ b/drools-eclipse/org.jbpm.eclipse/pom.xml
@@ -26,13 +26,13 @@
             <id>clean lib</id>
             <phase>clean</phase>
             <configuration>
-              <tasks>
+              <target>
                 <delete>
                   <fileset dir="lib" includes="**/*.jar" excludes="**/.svn"/>
                 </delete>
                 <delete dir="help/shared"/>
                 <delete dir="help/eclipse"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
Fixes the warning
"[WARNING] Parameter tasks is deprecated, use target instead"

See maven-antrun-plugin [docs](http://maven.apache.org/plugins/maven-antrun-plugin/run-mojo.html#tasks)

Also removed useless execution of antrun which has been commented out since 2011 by @ge0ffrey and nobody complained ever since :-)