### PR TITLE
DROOLS-5495: Drools Builder error

### DIFF
--- a/drools-eclipse/org.drools.eclipse/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.drools.eclipse/META-INF/MANIFEST.MF
@@ -65,7 +65,8 @@ Bundle-ClassPath: .,
  lib/jbpm-flow.jar,
  lib/jbpm-flow-builder.jar,
  lib/slf4j-api.jar,
- lib/protobuf-java.jar
+ lib/protobuf-java.jar,
+ lib/commons-math3.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.drools.compiler.compiler,
  org.drools.compiler.lang.descr,

--- a/drools-eclipse/org.drools.eclipse/pom.xml
+++ b/drools-eclipse/org.drools.eclipse/pom.xml
@@ -90,7 +90,8 @@
                 jbpm-flow,
                 jbpm-flow-builder,
                 slf4j-api,
-                protobuf-java
+                protobuf-java,
+                commons-math3
               </includeArtifactIds>
             </configuration>
           </execution>


### PR DESCRIPTION
"org/apache/commons/math3/util/ArithmeticUtils" by eclipse plugin
 - Adding missing commons-math3 dependency